### PR TITLE
Migrated Ingress for k8s v1.22

### DIFF
--- a/alb-controller/alb_front_full.yaml
+++ b/alb-controller/alb_front_full.yaml
@@ -56,7 +56,7 @@ spec:
       port: 80
       targetPort: 3000
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ecsdemo-frontend
@@ -69,7 +69,9 @@ spec:
   rules:
     - http:
         paths:
-          - path: /*
+          - pathType: ImplementationSpecific
             backend:
-              serviceName: "ecsdemo-frontend"
-              servicePort: 80
+              service:
+                name: "ecsdemo-frontend"
+                port:
+                  number: 80


### PR DESCRIPTION
The file is referenced by https://whchoi98.gitbook.io/k8s/5.eks-ingress/alb-ingress, but Ingress object is not v1.22 compatible.

Changed Ingress to support v1.22 of k8s.